### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/05a-train-register-model.yml
+++ b/.github/workflows/05a-train-register-model.yml
@@ -38,7 +38,7 @@ jobs:
       id: train
       run: |
         cd src   
-        echo "::set-output name=job_name::$(az ml job create --file ../dependencies/cli_job.yml | jq .display_name)"
+        echo "job_name=$(az ml job create --file ../dependencies/cli_job.yml | jq .display_name)" >> "$GITHUB_OUTPUT"
   register:
     runs-on: ubuntu-latest
     environment: DEV


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter